### PR TITLE
#7 Add parser option for unescaped strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key-values-ts",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A TypeScript parser for the KeyValues data format (also called Valve Data Format).",
   "keywords": [
     "KeyValues",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "testEnvironment": "node",
     "coveragePathIgnorePatterns": [
       "/node_modules/",
-      "/lib/"
+      "/lib/",
+      "/tests/"
     ]
   }
 }

--- a/src/ast_node.ts
+++ b/src/ast_node.ts
@@ -23,7 +23,7 @@ export interface BaseASTNode {
   readonly parent?: ASTNode;
   readonly pos?: NodePosition;
   readonly children?: ASTNode[];
-  readonly value?: string | null;
+  readonly value?: string;
 }
 
 export type KeyASTNode = StringASTNode;

--- a/src/ast_node_impl.ts
+++ b/src/ast_node_impl.ts
@@ -43,6 +43,7 @@ export abstract class ASTNodeImpl {
 
   public pos?: NodePosition;
   public parent: ASTNode | undefined;
+  public value?: string;
 
   constructor(pos?: NodePosition) {
     this.pos = pos;
@@ -51,8 +52,13 @@ export abstract class ASTNodeImpl {
   public children: ASTNode[] = [];
 
   public toString(): string {
-    const parentStr = this.parent ? ` parent: {${this.parent.toString()}}` : '';
-    return `type: ${this.type} (${this.pos?.offset}/${this.pos?.length})${parentStr}`;
+    const posStr = this.pos ? ` (${this.pos.offset}/${this.pos.length})` : '';
+    const parentStr = this.parent
+      ? `, parent: { ${this.parent.toString()} }`
+      : '';
+    const valueStr = this.value ? `, value: "${this.value}"` : '';
+
+    return `type: ${this.type}${posStr}${valueStr}${parentStr}`;
   }
 }
 
@@ -71,12 +77,10 @@ export class StringASTNodeImpl extends ASTNodeImpl implements StringASTNode {
 export class CommentASTNodeImpl extends ASTNodeImpl implements CommentASTNode {
   public type: 'comment' = 'comment';
   public value: string;
-  public isInline: boolean;
 
-  constructor(value: string, isInline?: boolean, pos?: NodePosition) {
+  constructor(value: string, pos?: NodePosition) {
     super(pos);
     this.value = value;
-    this.isInline = isInline ?? false;
   }
 }
 

--- a/src/key_values.ts
+++ b/src/key_values.ts
@@ -15,7 +15,7 @@ export class KeyValuesDocument {
     options?: ParserOptions
   ): KeyValuesDocument {
     const parser = new KeyValuesParser(options);
-    const root = parseWith(text, parser.keyValues);
+    const root = parseWith(text, parser.lexer, parser.keyValues);
 
     return new KeyValuesDocument(root);
   }

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -1,4 +1,5 @@
-import { buildLexer } from 'typescript-parsec';
+import { buildLexer, Lexer, Token } from 'typescript-parsec';
+import { ParserOptions } from './parser';
 
 export enum TokenKind {
   LBrace,
@@ -9,11 +10,40 @@ export enum TokenKind {
   QuotedString,
 }
 
-export const lexer = buildLexer([
-  [true, /^\{/g, TokenKind.LBrace],
-  [true, /^\}/g, TokenKind.RBrace],
-  [true, /^\s+/g, TokenKind.Space],
-  [true, /^[/][/][^\n]*\s*/g, TokenKind.Comment],
-  [true, /^[^\s{}"]+/g, TokenKind.UnquotedString],
-  [true, /^(?<!\\)"(?:[^"]|(?:\\"))*(?<!\\)"/g, TokenKind.QuotedString],
-]);
+export type TokenDef = [boolean, RegExp, TokenKind];
+
+export default class KeyValuesLexer {
+  public lexer: Lexer<TokenKind>;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(options?: ParserOptions) {
+    const openBrace: TokenDef = [true, /^\{/g, TokenKind.LBrace];
+    const closeBrace: TokenDef = [true, /^\}/g, TokenKind.RBrace];
+    const space: TokenDef = [true, /^\s+/g, TokenKind.Space];
+    const comment: TokenDef = [true, /^[/][/][^\n]*\s*/g, TokenKind.Comment];
+    const unquotedString: TokenDef = [
+      true,
+      /^[^\s{}"]+/g,
+      TokenKind.UnquotedString,
+    ];
+    const quotedString: TokenDef = [
+      true,
+      /^(?<!\\)"(?:[^"]|(?:\\"))*(?<!\\)"/g,
+      TokenKind.QuotedString,
+    ];
+
+    this.lexer = buildLexer([
+      openBrace,
+      closeBrace,
+      space,
+      comment,
+      unquotedString,
+      quotedString,
+    ]);
+  }
+
+  /** Parses the given text into tokens. */
+  public parse(input: string): Token<TokenKind> | undefined {
+    return this.lexer.parse(input);
+  }
+}

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -34,11 +34,11 @@ export default class KeyValuesLexer {
     if (this.settings.escapeStrings) {
       quotedString = [
         true,
-        /^(?<!\\)"(?:[^"]|(?:\\"))*(?<!\\)"/g,
+        /^(?<!\\)"(?:[^"\n]|(?:\\"))*(?<!\\)"/g,
         TokenKind.QuotedString,
       ];
     } else {
-      quotedString = [true, /^"[^"]*"/g, TokenKind.QuotedString];
+      quotedString = [true, /^"[^"\n]*"/g, TokenKind.QuotedString];
     }
 
     this.lexer = buildLexer([

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -11,7 +11,6 @@ import {
   kmid,
   Parser,
   rep_sc,
-  Lexer,
 } from 'typescript-parsec';
 
 import {
@@ -25,7 +24,7 @@ import {
   CommentASTNodeImpl,
 } from './ast_node_impl';
 
-import { TokenKind, lexer } from './lexer';
+import KeyValuesLexer, { TokenKind } from './lexer';
 
 export type Trivia = CommentASTNodeImpl | null;
 export type ObjectChild = PropertyASTNodeImpl | CommentASTNodeImpl;
@@ -67,7 +66,7 @@ export function getSettings(options?: ParserOptions): ParserSettings {
 }
 
 export default class KeyValuesParser {
-  public lexer: Lexer<TokenKind>;
+  public lexer: KeyValuesLexer;
   public settings: ParserSettings;
 
   // Non-recursive parsers
@@ -88,7 +87,7 @@ export default class KeyValuesParser {
   public keyValues: Parser<TokenKind, KeyValuesASTNodeImpl>;
 
   constructor(options?: ParserOptions) {
-    this.lexer = lexer;
+    this.lexer = new KeyValuesLexer(options);
     this.settings = getSettings(options);
 
     // Apply functions
@@ -324,6 +323,7 @@ export function some_sc<TKind, TResult>(
 
 export function parseWith<TResult>(
   text: string,
+  lexer: KeyValuesLexer,
   parser: Parser<TokenKind, TResult>
 ): TResult {
   return expectSingleResult(expectEOF(parser.parse(lexer.parse(text))));

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,7 +7,6 @@ import {
   apply,
   seq,
   alt,
-  opt_sc,
   kmid,
   Parser,
   rep_sc,
@@ -197,14 +196,14 @@ export default class KeyValuesParser {
       values: [
         Token<TokenKind.LBrace>,
         Trivia[],
-        [PropertyASTNodeImpl, Trivia[]][] | undefined,
+        [PropertyASTNodeImpl, Trivia[]][],
         Trivia[],
         Token<TokenKind.RBrace>
       ]
     ) => ObjectASTNodeImpl = (values) => {
       const lBrace = values[0];
       const preComments: ObjectChild[] = triviaToComments(values[1]);
-      const rawChildren = values[2] || [];
+      const rawChildren = values[2];
       const postComments: ObjectChild[] = triviaToComments(values[3]);
       const rBrace = values[4];
 
@@ -280,13 +279,11 @@ export default class KeyValuesParser {
         seq(
           this.openBrace, // A left brace ({) ...
           rep_sc(this.trivia), // ...followed by some trivia...
-          opt_sc(
-            // ...followed by an optional list of properties...
-            rep_sc(
-              seq(
-                property, //...containing properties...
-                some_sc(this.trivia) // ...separated by space or comments.
-              )
+          // ...followed by an optional list of properties...
+          rep_sc(
+            seq(
+              property, //...containing properties...
+              some_sc(this.trivia) // ...separated by space or comments.
             )
           ),
           rep_sc(this.trivia), // ...followed by some trivia...

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -146,7 +146,7 @@ export default class KeyValuesParser {
         value.pos.columnEnd
       );
 
-      return new CommentASTNodeImpl(comment, undefined, pos);
+      return new CommentASTNodeImpl(comment, pos);
     };
 
     const applySpace: (value: Token<TokenKind.Space>) => null = () => null;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -35,16 +35,24 @@ export type PropertyChild =
   | CommentASTNodeImpl;
 
 export interface ParserOptions {
-  /** Determines if the parser should include comments in the AST. */
+  /** Determines if the parser should include comments in the AST.
+   * Defaults to false.
+   */
   collectComments?: boolean;
+  /** Determines if string escaping should be enabled.
+   * Defaults to false.
+   */
+  escapeStrings?: boolean;
 }
 
 export interface ParserSettings extends ParserOptions {
   collectComments: boolean;
+  escapeStrings: boolean;
 }
 
 export const DEFAULT_SETTINGS: ParserSettings = {
   collectComments: false,
+  escapeStrings: false,
 };
 
 /** Converts the given options to settings. */
@@ -54,6 +62,7 @@ export function getSettings(options?: ParserOptions): ParserSettings {
   return {
     collectComments:
       options.collectComments ?? DEFAULT_SETTINGS.collectComments,
+    escapeStrings: options.escapeStrings ?? DEFAULT_SETTINGS.escapeStrings,
   };
 }
 

--- a/tests/ast_node.test.ts
+++ b/tests/ast_node.test.ts
@@ -2,9 +2,14 @@ import {
   StringASTNodeImpl,
   PropertyASTNodeImpl,
   ObjectASTNodeImpl,
-  NodePositionImpl,
 } from '../src/ast_node_impl';
 import { next, findAtOffset, findAtCell } from '../src/ast_node';
+import {
+  createStartPos,
+  createLinePos,
+  createStartLinePos,
+  createStringPropertyNode,
+} from './test_util';
 
 describe('ASTNode', () => {
   // Next
@@ -308,44 +313,3 @@ describe('ASTNode', () => {
     });
   });
 });
-
-/** Creates a simple string property node. */
-function createStringPropertyNode(
-  key: string,
-  value: string
-): PropertyASTNodeImpl {
-  const keyNode = new StringASTNodeImpl(key);
-  const valueNode = new StringASTNodeImpl(value);
-  const propertyNode = new PropertyASTNodeImpl(keyNode, valueNode);
-
-  return propertyNode;
-}
-
-function createStartPos(
-  length: number,
-  rowEnd: number,
-  columnEnd: number
-): NodePositionImpl {
-  return new NodePositionImpl(0, length, 1, 1, rowEnd, columnEnd);
-}
-
-function createLinePos(
-  offset: number,
-  length: number,
-  rowBegin?: number,
-  columnBegin?: number
-): NodePositionImpl {
-  return new NodePositionImpl(
-    offset,
-    length,
-    rowBegin ?? 1,
-    columnBegin ?? offset + 1,
-    rowBegin ?? 1,
-    (columnBegin ?? offset + 1) + length
-  );
-}
-
-/** Asserts that the position data of a single-line node is correct. */
-function createStartLinePos(length: number): NodePositionImpl {
-  return createStartPos(length, 1, length + 1);
-}

--- a/tests/ast_node_impl.test.ts
+++ b/tests/ast_node_impl.test.ts
@@ -4,6 +4,7 @@ import {
   CommentASTNodeImpl,
   ObjectASTNodeImpl,
 } from '../src/ast_node_impl';
+import { createStartLinePos } from './test_util';
 
 describe('ASTNodeImpl', () => {
   // String
@@ -212,6 +213,29 @@ describe('ASTNodeImpl', () => {
       expect(obj.children[1].parent).toBe(obj);
       expect(obj.children[2].parent).toBe(obj);
       expect(obj.children[3].parent).toBe(obj);
+    });
+  });
+  // To String
+  describe('toString', () => {
+    test('should stringify simple string node without position or parent', () => {
+      const str = new StringASTNodeImpl('value');
+      const expected = `type: string, value: "value"`;
+
+      expect(str.toString()).toEqual(expected);
+    });
+    test('should stringify simple key node without position', () => {
+      const key = new StringASTNodeImpl('key');
+      const value = new StringASTNodeImpl('value');
+      new PropertyASTNodeImpl(key, value);
+      const expected = `type: string, value: "key", parent: { type: property }`;
+
+      expect(key.toString()).toEqual(expected);
+    });
+    test('should stringify simple string node with position', () => {
+      const str = new StringASTNodeImpl('value', true, createStartLinePos(7));
+      const expected = `type: string (0/7), value: "value"`;
+
+      expect(str.toString()).toEqual(expected);
     });
   });
 });

--- a/tests/key_values.test.ts
+++ b/tests/key_values.test.ts
@@ -1,10 +1,16 @@
 import { stringify, parse, KeyValuesDocument } from '../src/key_values';
-import { PropertyASTNodeImpl, StringASTNodeImpl } from '../src/ast_node_impl';
+import {
+  PropertyASTNodeImpl,
+  StringASTNodeImpl,
+  ObjectASTNodeImpl,
+  NodePositionImpl,
+} from '../src/ast_node_impl';
 import { StringifyOptions } from '../src/node_stringifier';
 
 describe('KeyValues', () => {
   // KeyValues document
   describe('KeyValuesDocument', () => {
+    // From object
     describe('fromObject', () => {
       test('should extract single-property objects', () => {
         const obj = { key: 'value' };
@@ -12,6 +18,217 @@ describe('KeyValues', () => {
         const result = KeyValuesDocument.fromObject(obj);
 
         expect(result.root).toEqual(expectedRoot);
+      });
+      test('should not extract multi-property objects', () => {
+        const obj = { key1: 'value1', key2: 'value2' };
+        const expectedRoot = new ObjectASTNodeImpl([
+          createStringPropertyNode('key1', 'value1'),
+          createStringPropertyNode('key2', 'value2'),
+        ]);
+        const result = KeyValuesDocument.fromObject(obj);
+
+        expect(result.root).toEqual(expectedRoot);
+      });
+    });
+    // To object
+    describe('toObject', () => {
+      test('should fail with undefined root node', () => {
+        const doc = new KeyValuesDocument(undefined);
+        const fun = () => {
+          doc.toObject();
+        };
+
+        expect(fun).toThrow();
+      });
+      test('should convert simple string property', () => {
+        const doc = new KeyValuesDocument(
+          createStringPropertyNode('key', 'value')
+        );
+        const result = doc.toObject();
+        const expected = { key: 'value' };
+
+        expect(result).toEqual(expected);
+      });
+      test('should convert simple empty object property', () => {
+        const doc = new KeyValuesDocument(
+          new PropertyASTNodeImpl(
+            new StringASTNodeImpl('key'),
+            new ObjectASTNodeImpl([])
+          )
+        );
+        const result = doc.toObject();
+        const expected = { key: {} };
+
+        expect(result).toEqual(expected);
+      });
+      test('should convert simple string object property', () => {
+        const doc = new KeyValuesDocument(
+          new PropertyASTNodeImpl(
+            new StringASTNodeImpl('key1'),
+            new ObjectASTNodeImpl([
+              createStringPropertyNode('key1.1', 'value1.1'),
+            ])
+          )
+        );
+        const result = doc.toObject();
+        const expected = { key1: { 'key1.1': 'value1.1' } };
+
+        expect(result).toEqual(expected);
+      });
+    });
+    // To string
+    describe('toString', () => {
+      test('should return empty string with undefined root node', () => {
+        const doc = new KeyValuesDocument(undefined);
+        const result = doc.toString();
+        const expected = '';
+
+        expect(result).toEqual(expected);
+      });
+      test('should stringify simple string property document', () => {
+        const doc = new KeyValuesDocument(
+          createStringPropertyNode('key', 'value')
+        );
+        const result = doc.toString();
+        const expected = '"key"\t"value"';
+
+        expect(result).toEqual(expected);
+      });
+      test('should stringify simple empty object property document', () => {
+        const doc = new KeyValuesDocument(
+          new PropertyASTNodeImpl(
+            new StringASTNodeImpl('key'),
+            new ObjectASTNodeImpl([])
+          )
+        );
+        const result = doc.toString();
+        const expected = '"key"\t{}';
+
+        expect(result).toEqual(expected);
+      });
+      test('should stringify simple string object property document', () => {
+        const doc = new KeyValuesDocument(
+          new PropertyASTNodeImpl(
+            new StringASTNodeImpl('key1'),
+            new ObjectASTNodeImpl([
+              createStringPropertyNode('key1.1', 'value1.1'),
+            ])
+          )
+        );
+        const result = doc.toString();
+        const expected = '"key1"\n{ "key1.1"\t"value1.1" }';
+
+        expect(result).toEqual(expected);
+      });
+    });
+    // Find at offset
+    describe('findAtOffset', () => {
+      test('should return null for undefined root node', () => {
+        const doc = new KeyValuesDocument(undefined);
+        const result = doc.findAtOffset(0);
+        const expected = null;
+
+        expect(result).toEqual(expected);
+      });
+      test('should return key for offset in key', () => {
+        const key = new StringASTNodeImpl('key', true, createStartLinePos(5));
+        const value = new StringASTNodeImpl('value', true, createLinePos(6, 7));
+        // "key"  "value"
+        const property = new PropertyASTNodeImpl(
+          key,
+          value,
+          [],
+          createStartLinePos(14)
+        );
+        const doc = new KeyValuesDocument(property);
+        const result = doc.findAtOffset(0);
+
+        expect(result).toEqual(key);
+      });
+      test('should return value for offset in value', () => {
+        const key = new StringASTNodeImpl('key', true, createStartLinePos(5));
+        const value = new StringASTNodeImpl('value', true, createLinePos(6, 7));
+        // "key"  "value"
+        const property = new PropertyASTNodeImpl(
+          key,
+          value,
+          [],
+          createStartLinePos(14)
+        );
+        const doc = new KeyValuesDocument(property);
+        const result = doc.findAtOffset(8);
+
+        expect(result).toEqual(value);
+      });
+      test('should return property for offset in between key and value', () => {
+        const key = new StringASTNodeImpl('key', true, createStartLinePos(5));
+        const value = new StringASTNodeImpl('value', true, createLinePos(7, 7));
+        // "key"  "value"
+        const property = new PropertyASTNodeImpl(
+          key,
+          value,
+          [],
+          createStartLinePos(15)
+        );
+        const doc = new KeyValuesDocument(property);
+        const result = doc.findAtOffset(6);
+
+        expect(result).toEqual(property);
+      });
+    });
+    // Find at cell
+    describe('findAtCell', () => {
+      test('should return null for undefined root node', () => {
+        const doc = new KeyValuesDocument(undefined);
+        const result = doc.findAtCell(1, 1);
+        const expected = null;
+
+        expect(result).toEqual(expected);
+      });
+      test('should return key for cell in key', () => {
+        const key = new StringASTNodeImpl('key', true, createStartLinePos(5));
+        const value = new StringASTNodeImpl('value', true, createLinePos(6, 7));
+        // "key"  "value"
+        const property = new PropertyASTNodeImpl(
+          key,
+          value,
+          [],
+          createStartLinePos(14)
+        );
+        const doc = new KeyValuesDocument(property);
+        const result = doc.findAtCell(1, 1);
+
+        expect(result).toEqual(key);
+      });
+      test('should return value for cell in value', () => {
+        const key = new StringASTNodeImpl('key', true, createStartLinePos(5));
+        const value = new StringASTNodeImpl('value', true, createLinePos(6, 7));
+        // "key"  "value"
+        const property = new PropertyASTNodeImpl(
+          key,
+          value,
+          [],
+          createStartLinePos(14)
+        );
+        const doc = new KeyValuesDocument(property);
+        const result = doc.findAtCell(1, 9);
+
+        expect(result).toEqual(value);
+      });
+      test('should return property for cell in between key and value', () => {
+        const key = new StringASTNodeImpl('key', true, createStartLinePos(5));
+        const value = new StringASTNodeImpl('value', true, createLinePos(7, 7));
+        // "key"  "value"
+        const property = new PropertyASTNodeImpl(
+          key,
+          value,
+          [],
+          createStartLinePos(15)
+        );
+        const doc = new KeyValuesDocument(property);
+        const result = doc.findAtCell(1, 7);
+
+        expect(result).toEqual(property);
       });
     });
   });
@@ -118,4 +335,33 @@ function createStringPropertyNode(
   const propertyNode = new PropertyASTNodeImpl(keyNode, valueNode);
 
   return propertyNode;
+}
+
+function createStartPos(
+  length: number,
+  rowEnd: number,
+  columnEnd: number
+): NodePositionImpl {
+  return new NodePositionImpl(0, length, 1, 1, rowEnd, columnEnd);
+}
+
+function createLinePos(
+  offset: number,
+  length: number,
+  rowBegin?: number,
+  columnBegin?: number
+): NodePositionImpl {
+  return new NodePositionImpl(
+    offset,
+    length,
+    rowBegin ?? 1,
+    columnBegin ?? offset + 1,
+    rowBegin ?? 1,
+    (columnBegin ?? offset + 1) + length
+  );
+}
+
+/** Asserts that the position data of a single-line node is correct. */
+function createStartLinePos(length: number): NodePositionImpl {
+  return createStartPos(length, 1, length + 1);
 }

--- a/tests/key_values.test.ts
+++ b/tests/key_values.test.ts
@@ -3,9 +3,13 @@ import {
   PropertyASTNodeImpl,
   StringASTNodeImpl,
   ObjectASTNodeImpl,
-  NodePositionImpl,
 } from '../src/ast_node_impl';
 import { StringifyOptions } from '../src/node_stringifier';
+import {
+  createStringPropertyNode,
+  createStartLinePos,
+  createLinePos,
+} from './test_util';
 
 describe('KeyValues', () => {
   // KeyValues document
@@ -324,44 +328,3 @@ describe('KeyValues', () => {
     });
   });
 });
-
-/** Creates a simple string property node. */
-function createStringPropertyNode(
-  key: string,
-  value: string
-): PropertyASTNodeImpl {
-  const keyNode = new StringASTNodeImpl(key);
-  const valueNode = new StringASTNodeImpl(value);
-  const propertyNode = new PropertyASTNodeImpl(keyNode, valueNode);
-
-  return propertyNode;
-}
-
-function createStartPos(
-  length: number,
-  rowEnd: number,
-  columnEnd: number
-): NodePositionImpl {
-  return new NodePositionImpl(0, length, 1, 1, rowEnd, columnEnd);
-}
-
-function createLinePos(
-  offset: number,
-  length: number,
-  rowBegin?: number,
-  columnBegin?: number
-): NodePositionImpl {
-  return new NodePositionImpl(
-    offset,
-    length,
-    rowBegin ?? 1,
-    columnBegin ?? offset + 1,
-    rowBegin ?? 1,
-    (columnBegin ?? offset + 1) + length
-  );
-}
-
-/** Asserts that the position data of a single-line node is correct. */
-function createStartLinePos(length: number): NodePositionImpl {
-  return createStartPos(length, 1, length + 1);
-}

--- a/tests/node_parser.test.ts
+++ b/tests/node_parser.test.ts
@@ -4,12 +4,13 @@ import {
   ObjectASTNodeImpl,
 } from '../src/ast_node_impl';
 import * as NodeParser from '../src/node_parser';
+import { createStringPropertyNode } from './test_util';
 
 describe('NodeParser', () => {
   // String node
   describe('parseStringNode', () => {
     test('should parse simple string', () => {
-      const node = createStringNode('value');
+      const node = new StringASTNodeImpl('value');
       const expected = 'value';
 
       expect(NodeParser.parseStringNode(node)).toEqual(expected);
@@ -59,7 +60,7 @@ describe('NodeParser', () => {
       const node = new ObjectASTNodeImpl([
         createStringPropertyNode('key1', 'value1'),
         new PropertyASTNodeImpl(
-          createStringNode('key2'),
+          new StringASTNodeImpl('key2'),
           new ObjectASTNodeImpl([
             createStringPropertyNode('key2.1', 'value2.1'),
             createStringPropertyNode('key2.2', 'value2.2'),
@@ -85,20 +86,3 @@ describe('NodeParser', () => {
     });
   });
 });
-
-/** Creates a simple string node. */
-function createStringNode(value: string): StringASTNodeImpl {
-  return new StringASTNodeImpl(value);
-}
-
-/** Creates a simple string property node. */
-function createStringPropertyNode(
-  key: string,
-  value: string
-): PropertyASTNodeImpl {
-  const keyNode = createStringNode(key);
-  const valueNode = createStringNode(value);
-  const propertyNode = new PropertyASTNodeImpl(keyNode, valueNode);
-
-  return propertyNode;
-}

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,5 +1,5 @@
 import KeyValuesParser, { parseWith } from '../src/parser';
-import { ASTNode } from '../src/ast_node';
+import { assertPos, assertSingleLinePos, assertStartPos } from './test_util';
 
 let parser: KeyValuesParser;
 
@@ -455,36 +455,3 @@ describe('Parser', () => {
     });
   });
 });
-
-/** Asserts that the position data of a node is correct. */
-function assertPos(
-  node: ASTNode,
-  offset: number,
-  length: number,
-  rowBegin: number,
-  columnBegin: number,
-  rowEnd: number,
-  columnEnd: number
-) {
-  expect(node.pos?.offset).toBe(offset);
-  expect(node.pos?.length).toBe(length);
-  expect(node.pos?.rowBegin).toBe(rowBegin);
-  expect(node.pos?.columnBegin).toBe(columnBegin);
-  expect(node.pos?.rowEnd).toBe(rowEnd);
-  expect(node.pos?.columnEnd).toBe(columnEnd);
-}
-
-/** Asserts that the position of a node at the start of the text is correct. */
-function assertStartPos(
-  node: ASTNode,
-  length: number,
-  rowEnd: number,
-  columnEnd: number
-) {
-  assertPos(node, 0, length, 1, 1, rowEnd, columnEnd);
-}
-
-/** Asserts that the position data of a single-line node is correct. */
-function assertSingleLinePos(node: ASTNode, length: number) {
-  assertStartPos(node, length, 1, length + 1);
-}

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -18,6 +18,46 @@ describe('Parser', () => {
       expect(result.value).toEqual('value');
       assertSingleLinePos(result, 5);
     });
+    test('should fail with quotes', () => {
+      const text = `value"`;
+      const fun = () => {
+        parseWith(text, parser.lexer, parser.unquotedString);
+      };
+
+      expect(fun).toThrow();
+    });
+    test('should fail with spaces', () => {
+      const text = `value `;
+      const fun = () => {
+        parseWith(text, parser.lexer, parser.unquotedString);
+      };
+
+      expect(fun).toThrow();
+    });
+    test('should fail with tabs', () => {
+      const text = `value\t`;
+      const fun = () => {
+        parseWith(text, parser.lexer, parser.unquotedString);
+      };
+
+      expect(fun).toThrow();
+    });
+    test('should fail with newline', () => {
+      const text = `value\n`;
+      const fun = () => {
+        parseWith(text, parser.lexer, parser.unquotedString);
+      };
+
+      expect(fun).toThrow();
+    });
+    test('should fail with open brace', () => {
+      const text = `value{`;
+      const fun = () => {
+        parseWith(text, parser.lexer, parser.unquotedString);
+      };
+
+      expect(fun).toThrow();
+    });
   });
   // Quoted string
   describe('quoted string', () => {
@@ -29,6 +69,32 @@ describe('Parser', () => {
       expect(result.isQuoted).toBeTruthy();
       expect(result.value).toEqual('value');
       assertSingleLinePos(result, 7);
+    });
+    test('should parse string with braces', () => {
+      const text = `"value{}"`;
+      const result = parseWith(text, parser.lexer, parser.quotedString);
+
+      expect(result.type).toEqual('string');
+      expect(result.isQuoted).toBeTruthy();
+      expect(result.value).toEqual('value{}');
+      assertSingleLinePos(result, 9);
+    });
+    test('should parse string with spaces and tabs', () => {
+      const text = `"value \t"`;
+      const result = parseWith(text, parser.lexer, parser.quotedString);
+
+      expect(result.type).toEqual('string');
+      expect(result.isQuoted).toBeTruthy();
+      expect(result.value).toEqual('value \t');
+      assertSingleLinePos(result, 9);
+    });
+    test('should fail with newline', () => {
+      const text = `"value\n"`;
+      const fun = () => {
+        parseWith(text, parser.lexer, parser.quotedString);
+      };
+
+      expect(fun).toThrow();
     });
     test('should parse string with spacing', () => {
       const text = `"value 1 and 2"`;
@@ -74,7 +140,7 @@ describe('Parser', () => {
       expect(result.value).toEqual('value');
       assertSingleLinePos(result, 5);
     });
-    test('should parse simple quotedstring', () => {
+    test('should parse simple quoted string', () => {
       const text = `"value"`;
       const result = parseWith(text, parser.lexer, parser.string);
 

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -11,7 +11,7 @@ describe('Parser', () => {
   describe('unquoted string', () => {
     test('should parse simple string', () => {
       const text = `value`;
-      const result = parseWith(text, parser.unquotedString);
+      const result = parseWith(text, parser.lexer, parser.unquotedString);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeFalsy();
@@ -23,7 +23,7 @@ describe('Parser', () => {
   describe('quoted string', () => {
     test('should parse simple string', () => {
       const text = `"value"`;
-      const result = parseWith(text, parser.quotedString);
+      const result = parseWith(text, parser.lexer, parser.quotedString);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeTruthy();
@@ -32,7 +32,7 @@ describe('Parser', () => {
     });
     test('should parse string with spacing', () => {
       const text = `"value 1 and 2"`;
-      const result = parseWith(text, parser.quotedString);
+      const result = parseWith(text, parser.lexer, parser.quotedString);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeTruthy();
@@ -41,7 +41,7 @@ describe('Parser', () => {
     });
     test('should allow escaped double quote', () => {
       const text = `"value\\"WithQuote"`;
-      const result = parseWith(text, parser.quotedString);
+      const result = parseWith(text, parser.lexer, parser.quotedString);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeTruthy();
@@ -53,7 +53,7 @@ describe('Parser', () => {
   describe('string', () => {
     test('should parse simple unquoted string', () => {
       const text = `value`;
-      const result = parseWith(text, parser.string);
+      const result = parseWith(text, parser.lexer, parser.string);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeFalsy();
@@ -62,7 +62,7 @@ describe('Parser', () => {
     });
     test('should parse simple quotedstring', () => {
       const text = `"value"`;
-      const result = parseWith(text, parser.string);
+      const result = parseWith(text, parser.lexer, parser.string);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeTruthy();
@@ -71,7 +71,7 @@ describe('Parser', () => {
     });
     test('should parse quoted string with spacing', () => {
       const text = `"value 1 and 2"`;
-      const result = parseWith(text, parser.string);
+      const result = parseWith(text, parser.lexer, parser.string);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeTruthy();
@@ -83,7 +83,7 @@ describe('Parser', () => {
   describe('comment', () => {
     test('should parse simple comment', () => {
       const text = `// Comment`;
-      const result = parseWith(text, parser.comment);
+      const result = parseWith(text, parser.lexer, parser.comment);
 
       expect(result.type).toEqual('comment');
       expect(result.value).toEqual('Comment');
@@ -94,7 +94,7 @@ describe('Parser', () => {
   describe('key', () => {
     test('should parse simple unquoted string', () => {
       const text = `value`;
-      const result = parseWith(text, parser.key);
+      const result = parseWith(text, parser.lexer, parser.key);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeFalsy;
@@ -103,7 +103,7 @@ describe('Parser', () => {
     });
     test('should parse simple quoted string', () => {
       const text = `"value"`;
-      const result = parseWith(text, parser.key);
+      const result = parseWith(text, parser.lexer, parser.key);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeTruthy();
@@ -112,7 +112,7 @@ describe('Parser', () => {
     });
     test('should parse quoted string with spacing', () => {
       const text = `"value 1 and 2"`;
-      const result = parseWith(text, parser.key);
+      const result = parseWith(text, parser.lexer, parser.key);
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeTruthy();
@@ -124,7 +124,7 @@ describe('Parser', () => {
   describe('object', () => {
     test('should parse empty object', () => {
       const text = `{}`;
-      const result = parseWith(text, parser.object);
+      const result = parseWith(text, parser.lexer, parser.object);
 
       expect(result.type).toEqual('object');
       expect(result.properties).toEqual([]);
@@ -132,7 +132,7 @@ describe('Parser', () => {
     });
     test('should parse simple single string object', () => {
       const text = `{ "key" "value" }`;
-      const result = parseWith(text, parser.object);
+      const result = parseWith(text, parser.lexer, parser.object);
 
       expect(result.type).toEqual('object');
       expect(result.properties.length).toBe(1);
@@ -148,7 +148,7 @@ describe('Parser', () => {
         "key2" "value2"
         "key3" "value3"
       }`;
-      const result = parseWith(text, parser.object);
+      const result = parseWith(text, parser.lexer, parser.object);
 
       expect(result.type).toEqual('object');
       expect(result.properties.length).toBe(3);
@@ -172,7 +172,7 @@ describe('Parser', () => {
         "key3" "value3"
         // Comment 4
       }`;
-      const result = parseWith(text, parser.object);
+      const result = parseWith(text, parser.lexer, parser.object);
 
       expect(result.type).toEqual('object');
       expect(result.properties.length).toBe(3);
@@ -198,7 +198,7 @@ describe('Parser', () => {
         "key3" "value3"
         // Comment 4
       }`;
-      const result = parseWith(text, commentParser.object);
+      const result = parseWith(text, parser.lexer, commentParser.object);
 
       expect(result.type).toEqual('object');
       expect(result.properties.length).toBe(3);
@@ -225,7 +225,7 @@ describe('Parser', () => {
         }
         "key3" "value3"
       }`;
-      const result = parseWith(text, parser.object);
+      const result = parseWith(text, parser.lexer, parser.object);
 
       expect(result.type).toEqual('object');
       expect(result.properties.length).toBe(3);
@@ -249,7 +249,7 @@ describe('Parser', () => {
   describe('value', () => {
     test('should parse simple unquoted string', () => {
       const text = `value`;
-      const result = parseWith(text, parser.value);
+      const result = parseWith(text, parser.lexer, parser.value);
 
       expect(result.type).toEqual('string');
       expect(result.value).toEqual('value');
@@ -257,7 +257,7 @@ describe('Parser', () => {
     });
     test('should parse simple quotedstring', () => {
       const text = `"value"`;
-      const result = parseWith(text, parser.value);
+      const result = parseWith(text, parser.lexer, parser.value);
 
       expect(result.type).toEqual('string');
       expect(result.value).toEqual('value');
@@ -265,7 +265,7 @@ describe('Parser', () => {
     });
     test('should parse quoted string with spacing', () => {
       const text = `"value 1 and 2"`;
-      const result = parseWith(text, parser.value);
+      const result = parseWith(text, parser.lexer, parser.value);
 
       expect(result.type).toEqual('string');
       expect(result.value).toEqual('value 1 and 2');
@@ -276,7 +276,7 @@ describe('Parser', () => {
   describe('property', () => {
     test('should parse simple string property', () => {
       const text = `"key" "value"`;
-      const result = parseWith(text, parser.property);
+      const result = parseWith(text, parser.lexer, parser.property);
 
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key');
@@ -285,7 +285,7 @@ describe('Parser', () => {
     });
     test('should parse empty object property', () => {
       const text = `"key" {}`;
-      const result = parseWith(text, parser.property);
+      const result = parseWith(text, parser.lexer, parser.property);
 
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key');
@@ -294,7 +294,7 @@ describe('Parser', () => {
     });
     test('should allow comments between key and string value', () => {
       const text = `"key"// Comment\n"value"`;
-      const result = parseWith(text, parser.property);
+      const result = parseWith(text, parser.lexer, parser.property);
 
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key');
@@ -303,7 +303,7 @@ describe('Parser', () => {
     });
     test('should allow comments between key and object value', () => {
       const text = `"key"// Comment\n{ "key1"\t"value1" }`;
-      const result = parseWith(text, parser.property);
+      const result = parseWith(text, parser.lexer, parser.property);
 
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key');
@@ -313,7 +313,7 @@ describe('Parser', () => {
     test('should include comments in the AST if enabled', () => {
       const commentParser = new KeyValuesParser({ collectComments: true });
       const text = `"key"// Comment\n{ "key1"\t"value1" }`;
-      const result = parseWith(text, commentParser.property);
+      const result = parseWith(text, parser.lexer, commentParser.property);
 
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key');
@@ -323,7 +323,7 @@ describe('Parser', () => {
     });
     test('should parse simple single string object property', () => {
       const text = `"key1" { "key1.1" "value1.1" }`;
-      const result = parseWith(text, parser.property);
+      const result = parseWith(text, parser.lexer, parser.property);
 
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key1');
@@ -335,7 +335,7 @@ describe('Parser', () => {
   describe('key values', () => {
     test('should parse simple string property', () => {
       const text = `"key" "value"`;
-      const result = parseWith(text, parser.keyValues);
+      const result = parseWith(text, parser.lexer, parser.keyValues);
 
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key');
@@ -344,7 +344,7 @@ describe('Parser', () => {
     });
     test('should parse object property', () => {
       const text = `"key" {}`;
-      const result = parseWith(text, parser.keyValues);
+      const result = parseWith(text, parser.lexer, parser.keyValues);
 
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key');
@@ -355,7 +355,7 @@ describe('Parser', () => {
       const text = `  
          "key" "value"   
          `;
-      const result = parseWith(text, parser.keyValues);
+      const result = parseWith(text, parser.lexer, parser.keyValues);
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key');
       expect(result.valueNode.value).toEqual('value');
@@ -366,7 +366,7 @@ describe('Parser', () => {
         // Comment 1
         "key" "value"   // Comment 2
         // Comment 3`;
-      const result = parseWith(text, parser.keyValues);
+      const result = parseWith(text, parser.lexer, parser.keyValues);
 
       expect(result.type).toEqual('property');
       expect(result.keyNode.value).toEqual('key');

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -39,9 +39,23 @@ describe('Parser', () => {
       expect(result.value).toEqual('value 1 and 2');
       assertSingleLinePos(result, 15);
     });
-    test('should allow escaped double quote', () => {
+    test('should not allow escaped double quote if disabled', () => {
+      const unescapedParser = new KeyValuesParser({ escapeStrings: false });
       const text = `"value\\"WithQuote"`;
-      const result = parseWith(text, parser.lexer, parser.quotedString);
+      const fun = () => {
+        parseWith(text, unescapedParser.lexer, unescapedParser.quotedString);
+      };
+
+      expect(fun).toThrow();
+    });
+    test('should allow escaped double quote if enabled', () => {
+      const escapeParser = new KeyValuesParser({ escapeStrings: true });
+      const text = `"value\\"WithQuote"`;
+      const result = parseWith(
+        text,
+        escapeParser.lexer,
+        escapeParser.quotedString
+      );
 
       expect(result.type).toEqual('string');
       expect(result.isQuoted).toBeTruthy();

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -1,0 +1,80 @@
+import { ASTNode } from '../src/ast_node';
+import {
+  NodePositionImpl,
+  PropertyASTNodeImpl,
+  StringASTNodeImpl,
+} from '../src/ast_node_impl';
+
+/** Asserts that the position data of a node is correct. */
+export function assertPos(
+  node: ASTNode,
+  offset: number,
+  length: number,
+  rowBegin: number,
+  columnBegin: number,
+  rowEnd: number,
+  columnEnd: number
+): void {
+  expect(node.pos?.offset).toBe(offset);
+  expect(node.pos?.length).toBe(length);
+  expect(node.pos?.rowBegin).toBe(rowBegin);
+  expect(node.pos?.columnBegin).toBe(columnBegin);
+  expect(node.pos?.rowEnd).toBe(rowEnd);
+  expect(node.pos?.columnEnd).toBe(columnEnd);
+}
+
+/** Asserts that the position of a node at the start of the text is correct. */
+export function assertStartPos(
+  node: ASTNode,
+  length: number,
+  rowEnd: number,
+  columnEnd: number
+): void {
+  assertPos(node, 0, length, 1, 1, rowEnd, columnEnd);
+}
+
+/** Asserts that the position data of a single-line node is correct. */
+export function assertSingleLinePos(node: ASTNode, length: number): void {
+  assertStartPos(node, length, 1, length + 1);
+}
+
+/** Creates a simple string property node. */
+export function createStringPropertyNode(
+  key: string,
+  value: string
+): PropertyASTNodeImpl {
+  const keyNode = new StringASTNodeImpl(key);
+  const valueNode = new StringASTNodeImpl(value);
+  const propertyNode = new PropertyASTNodeImpl(keyNode, valueNode);
+
+  return propertyNode;
+}
+
+export function createStartPos(
+  length: number,
+  rowEnd: number,
+  columnEnd: number
+): NodePositionImpl {
+  return new NodePositionImpl(0, length, 1, 1, rowEnd, columnEnd);
+}
+
+export function createLinePos(
+  offset: number,
+  length: number,
+  rowBegin?: number,
+  columnBegin?: number
+): NodePositionImpl {
+  return new NodePositionImpl(
+    offset,
+    length,
+    rowBegin ?? 1,
+    columnBegin ?? offset + 1,
+    rowBegin ?? 1,
+    (columnBegin ?? offset + 1) + length
+  );
+}
+
+/** Asserts that the position data of a single-line node is correct. */
+export function createStartLinePos(length: number): NodePositionImpl {
+  return createStartPos(length, 1, length + 1);
+}


### PR DESCRIPTION
- Adds a parser option to control if string escaping is allowed
- Improve test coverage
- Released as v0.5.1

Closes #7.