### PR TITLE
#30 Fix character escaping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key-values-ts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A TypeScript parser for the KeyValues data format (also called Valve Data Format).",
   "keywords": [
     "KeyValues",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -119,8 +119,13 @@ export default class KeyValuesParser {
 
       // Extract string value
       let str = value.text.slice(1, value.text.length - 1);
-      // Resolve escaped quotes
-      str = str.replace(/\\"/, '"');
+
+      if (this.settings.escapeStrings) {
+        // Resolve escaped quotes
+        str = str.replace(/\\"/, '"');
+        str = str.replace(/\\n/, '\n');
+        str = str.replace(/\\t/, '\t');
+      }
 
       return new StringASTNodeImpl(str, true, pos);
     };

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -114,7 +114,35 @@ describe('Parser', () => {
 
       expect(fun).toThrow();
     });
-    test('should allow escaped double quote if enabled', () => {
+    test('should not process escaped linebreak if disabled', () => {
+      const escapeParser = new KeyValuesParser({ escapeStrings: false });
+      const text = `"value\\nWithLinebreak"`;
+      const result = parseWith(
+        text,
+        escapeParser.lexer,
+        escapeParser.quotedString
+      );
+
+      expect(result.type).toEqual('string');
+      expect(result.isQuoted).toBeTruthy();
+      expect(result.value).toEqual('value\\nWithLinebreak');
+      assertSingleLinePos(result, 22);
+    });
+    test('should not process escaped tab if disabled', () => {
+      const escapeParser = new KeyValuesParser({ escapeStrings: false });
+      const text = `"value\\tWithTab"`;
+      const result = parseWith(
+        text,
+        escapeParser.lexer,
+        escapeParser.quotedString
+      );
+
+      expect(result.type).toEqual('string');
+      expect(result.isQuoted).toBeTruthy();
+      expect(result.value).toEqual('value\\tWithTab');
+      assertSingleLinePos(result, 16);
+    });
+    test('should process escaped double quote if enabled', () => {
       const escapeParser = new KeyValuesParser({ escapeStrings: true });
       const text = `"value\\"WithQuote"`;
       const result = parseWith(
@@ -127,6 +155,34 @@ describe('Parser', () => {
       expect(result.isQuoted).toBeTruthy();
       expect(result.value).toEqual('value"WithQuote');
       assertSingleLinePos(result, 18);
+    });
+    test('should process escaped linebreak if enabled', () => {
+      const escapeParser = new KeyValuesParser({ escapeStrings: true });
+      const text = `"value\\nWithLinebreak"`;
+      const result = parseWith(
+        text,
+        escapeParser.lexer,
+        escapeParser.quotedString
+      );
+
+      expect(result.type).toEqual('string');
+      expect(result.isQuoted).toBeTruthy();
+      expect(result.value).toEqual('value\nWithLinebreak');
+      assertSingleLinePos(result, 22);
+    });
+    test('should process escaped tab if enabled', () => {
+      const escapeParser = new KeyValuesParser({ escapeStrings: true });
+      const text = `"value\\tWithTab"`;
+      const result = parseWith(
+        text,
+        escapeParser.lexer,
+        escapeParser.quotedString
+      );
+
+      expect(result.type).toEqual('string');
+      expect(result.isQuoted).toBeTruthy();
+      expect(result.value).toEqual('value\tWithTab');
+      assertSingleLinePos(result, 16);
     });
   });
   // String


### PR DESCRIPTION
- Fix character escaping for `\n` and `\t`
- Released as v0.5.2

Closes #30.